### PR TITLE
Add support for multiple route tables per number of natgateway

### DIFF
--- a/nat_gateway.tf
+++ b/nat_gateway.tf
@@ -43,7 +43,7 @@ resource "aws_route_table" "nat_gateway" {
 
 resource "aws_route" "nat_gateway" {
   for_each               = var.enable_nat_gateway == true ? local.public_subnets : {}
-  route_table_id         = aws_route_table.nat_gateway[0].id
+  route_table_id         = aws_route_table.nat_gateway[each.key].id
   nat_gateway_id         = aws_nat_gateway.ngw[each.value].id
   destination_cidr_block = "0.0.0.0/0"
 }

--- a/nat_gateway.tf
+++ b/nat_gateway.tf
@@ -28,8 +28,8 @@ resource "aws_nat_gateway" "ngw" {
 }
 
 resource "aws_route_table" "nat_gateway" {
-  count  = var.enable_nat_gateway == true ? 1 : 0
-  vpc_id = aws_vpc.main.id
+  for_each = var.enable_nat_gateway == true ? local.public_subnets : {}
+  vpc_id   = aws_vpc.main.id
 
   tags = merge(
     {

--- a/nat_gateway.tf
+++ b/nat_gateway.tf
@@ -33,7 +33,9 @@ resource "aws_route_table" "nat_gateway" {
 
   tags = merge(
     {
-      "Name" = format("%s-rt-nat-gateway", var.name)
+      "Name" = format("%s-rt-nat-gateway-%s",
+        var.name,
+      substr(aws_nat_gateway.ngw[each.key].id, 4, 3)) // format id to get 3 random values
     },
     var.vpc_tags
   )

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "public_route_table_id" {
 }
 
 output "private_route_table_id" {
-  value = try(aws_route_table.nat_gateway[0].id, "")
+  value = [for rt in aws_route_table.nat_gateway : rt.id]
 }
 
 output "internet_gateway_id" {


### PR DESCRIPTION
Fixes an issue where mulitple natgatways could be created and subnets were associated to only one route table.